### PR TITLE
Fix Type Error: Add catch to Promise for deleteCustomer in widget.tsx

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -24,8 +24,6 @@ export function saveCustomer(customer: Customer): void {
   localStorage.setItem(customer.id, JSON.stringify({name: customer.name, email: customer.email}));
 }
 
-// Previously this was a synchronous function that just called localStorage.removeItem()
-// Changed to Promise to properly handle potential errors
 export function deleteCustomer(customerId: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     try {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -24,6 +24,15 @@ export function saveCustomer(customer: Customer): void {
   localStorage.setItem(customer.id, JSON.stringify({name: customer.name, email: customer.email}));
 }
 
-export function deleteCustomer(customerId: string): void {
-  localStorage.removeItem(customerId);
+// Previously this was a synchronous function that just called localStorage.removeItem()
+// Changed to Promise to properly handle potential errors
+export function deleteCustomer(customerId: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    try {
+      localStorage.removeItem(customerId);
+      resolve();
+    } catch (error) {
+      reject(error);
+    }
+  });
 }


### PR DESCRIPTION
This PR addresses a TypeScript compile error where the catch method was incorrectly used on a void type. The issue was in the widget.tsx file, where deleteCustomer(customer.id) did not return a Promise, causing the TypeScript error.

The deleteCustomer function has been updated to return a Promise<void>, ensuring that the function behaves correctly in asynchronous code and can be chained with .catch() for error handling.

Changes:
Updated deleteCustomer function to return a Promise<void> for proper asynchronous handling.

The function now resolves when localStorage.removeItem(customerId) is successful and rejects if any error occurs during the operation.